### PR TITLE
Fix Unknown column 'ent.row_id' for M2.3.6

### DIFF
--- a/Command/CatalogAbstract.php
+++ b/Command/CatalogAbstract.php
@@ -192,7 +192,7 @@ abstract class CatalogAbstract extends Command
             )
             ->reset(Select::COLUMNS)
             ->columns('value')
-            ->where('ent.row_id IS NULL');
+            ->where('ent.entity_id IS NULL');
         $this->orphanedMediaGalleryPaths = $connection->fetchCol($select);
         //add the directory path to each value because the DB only stores the path relative to the media directory
         $mediaDirectoryPath = $this->getMediaDirectoryPath();


### PR DESCRIPTION
I got this error in Magento 2.3.6
```
❯ bin/magento catalog:media:info -vvv

Exception:
SQLSTATE[42S22]: Column not found: 1054 Unknown column 'ent.row_id' in 'where clause', query was: SELECT `gal`.`value` FROM `catalog_product_entity_media_gallery` AS `gal`
 LEFT JOIN `catalog_product_entity_media_gallery_value_to_entity` AS `ent` ON gal.value_id=ent.value_id WHERE (ent.row_id IS NULL)
 ```